### PR TITLE
Issue/layermanager/closethread：ウィンドウ終了時の動作を改良

### DIFF
--- a/src/Graphics/Layer/LayerManager.cpp
+++ b/src/Graphics/Layer/LayerManager.cpp
@@ -201,10 +201,6 @@ void jubeon::graphics::LayerManager::process(void)
 		//画面描写
 		this->window->draw(wsp);
 
-		sf::CircleShape cp(50, 10);
-		cp.setPosition(200, 200);
-		cp.setFillColor(sf::Color::Red);
-		//this->window->draw(cp);
 
 		//画面アップデート
 		this->window->display();
@@ -215,6 +211,7 @@ void jubeon::graphics::LayerManager::process(void)
 
 	//残ってるものすべて削除
 	for (auto p = this->layer_list.begin(); p != this->layer_list.end(); ) {
+		(*p)->setExitCode(0);
 		(*p)->Exit();
 		p = this->layer_list.erase(p);
 	}

--- a/src/Graphics/Layer/LayerManager.cpp
+++ b/src/Graphics/Layer/LayerManager.cpp
@@ -211,7 +211,7 @@ void jubeon::graphics::LayerManager::process(void)
 
 	//c‚Á‚Ä‚é‚à‚Ì‚·‚×‚Äíœ
 	for (auto p = this->layer_list.begin(); p != this->layer_list.end(); ) {
-		(*p)->setExitCode(0);
+		(*p)->setExitCode(1);
 		(*p)->Exit();
 		p = this->layer_list.erase(p);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,9 @@ int main(int argc, char * argv[]) {
 	//シーン処理開始
 	int ret = Scene::process(&mainwindow, std::move(upGameSceneInstance));
 
+	//現在起動中のウィンドウを終了し、レイヤーを全部解放
+	mainwindow.closeWindow();
+
 	//システム終了
 	return ret;
 


### PR DESCRIPTION
mainが終了する際に描画スレッドの破棄を忘れていた。